### PR TITLE
fix: Resolved issue with incorrect product path of refena_inspector on Windows 11

### DIFF
--- a/refena_inspector/bin/refena_inspector.dart
+++ b/refena_inspector/bin/refena_inspector.dart
@@ -193,7 +193,7 @@ void main() async {
           '/h',
           '/i',
           '/y',
-          '$_compilePath\\build\\$device\\runner\\Release',
+          '$_compilePath\\build\\$device\\x64\\runner\\Release',
           _appPath,
         ],
         workingDirectory: _inspectorPath,


### PR DESCRIPTION
I encounter issues on windows11: "'.refena_inspector\app\refena_inspector.exe' is not recognized as an internal or external command, operable program or batch file".

the product path of `refena_inspector` is `\\build\\$device\\x64\\runner\\Release` instead of `\\build\\$device\\runner\\Release` on windows11

Related files:

- `refena_inspector/bin/refena_inspector.dart`